### PR TITLE
Fix error on SMTP with no AUTH

### DIFF
--- a/easy-wp-smtp/easy-wp-smtp.php
+++ b/easy-wp-smtp/easy-wp-smtp.php
@@ -189,6 +189,7 @@ class EasyWPSMTP {
 		$phpmailer->Port = $this->opts['smtp_settings']['port'];
 
 		/* If we're using smtp auth, set the username & password */
+		$phpmailer->SMTPAuth = false;
 		if ( 'yes' === $this->opts['smtp_settings']['autentication'] ) {
 			$phpmailer->SMTPAuth = true;
 			$phpmailer->Username = $this->opts['smtp_settings']['username'];


### PR DESCRIPTION
Strangely the test email works perfectly with no auth on a local SMTP server that is expecting no auth, but other emails (gravity forms, admin notifications) are rejected. Explicitely declaring  $phpmailer->SMTPAuth to false, before the setting is changed (or not) by config, solves the issue